### PR TITLE
Building wifi hal code with WIFI_HAL_VERSION_3

### DIFF
--- a/source/wifi/wifi_hal.c
+++ b/source/wifi/wifi_hal.c
@@ -8717,4 +8717,10 @@ INT wifi_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
     return RETURN_OK;
 }
 
+INT wifi_getHalCapability(wifi_hal_capability_t *cap)
+{
+    //TODO
+    return RETURN_OK;
+}
+
 #endif /* WIFI_HAL_VERSION_3 */


### PR DESCRIPTION
REFPLTB-1457: Building wifi hal code with WIFI_HAL_VERSION_3

Reason for change: wifi_hal3.0 compilation for Turris-Omnia
Test Procedure: Build and test
Risk: low

Signed-off-by: KaviyaKumaresan <Kaviya.Kumaresan@ltts.com>