### PR TITLE
REFPLTB-1457: Fix issue with empty ssid

### DIFF
--- a/source/wifi/wifi_hal.c
+++ b/source/wifi/wifi_hal.c
@@ -2696,7 +2696,7 @@ INT wifi_setSSIDName(INT apIndex, CHAR *ssid_string)
     char config_file[MAX_BUF_SIZE] = {0};
 
     WIFI_ENTRY_EXIT_DEBUG("Inside %s:%d\n",__func__, __LINE__);
-    if(NULL == ssid_string || strlen(ssid_string) >= 32 )
+    if(NULL == ssid_string || strlen(ssid_string) >= 32 || strlen(ssid_string) == 0 )
         return RETURN_ERR;
 
     params.name = "ssid";


### PR DESCRIPTION
SSID cannot be empty in hostapd config.
Empty string in ssid breaks hostapd config.
