### PR TITLE
RDK-592: Update radio index at capability structure

### DIFF
--- a/source/wifi/wifi_hal.c
+++ b/source/wifi/wifi_hal.c
@@ -9397,6 +9397,7 @@ static int getRadioCapabilities(int radioIndex, wifi_radio_capabilities_t *rcap)
         return RETURN_ERR;
     }
 
+    rcap->index = radioIndex;
     rcap->numSupportedFreqBand = 1;
     if (1 == radioIndex)
       rcap->band[0] = WIFI_FREQUENCY_5_BAND;


### PR DESCRIPTION
The structure wifi_radio_capabilities_t has radio index field which should be initialized.

Signed-off-by: Tomasz Kilarski <tkilarski@plume.com>