### PR TITLE
RDK-581: Avoid caching hostapd configuration

### DIFF
--- a/source/wifi/wifi_hal.c
+++ b/source/wifi/wifi_hal.c
@@ -416,16 +416,15 @@ static int _syscmd(char *cmd, char *retBuf, int retBufSize)
 
 static int wifi_hostapdCheck(int apIndex)
 {
+    char fname[MAX_BUF_SIZE];
+
     if (apIndex >= MAX_APS)
         return RETURN_ERR;
 
-    if (!hapd_conf[apIndex].valid)
-    {
-        char fname[MAX_BUF_SIZE];
-        snprintf(fname, sizeof(fname), "%s%d.conf", CONFIG_PREFIX, apIndex);
-        return hapd_read_cfg(hapd_conf + apIndex, fname);
-    }
-    return RETURN_OK;
+    // TODO: verify if data is consistent with configuration file content,
+    // then no need to read again (note potential opensync / wifiagent race).
+    snprintf(fname, sizeof(fname), "%s%d.conf", CONFIG_PREFIX, apIndex);
+    return hapd_read_cfg(hapd_conf + apIndex, fname);
 }
 
 static int wifi_hostapdRead(int apIndex, char *param, char *output, int outputSize)

--- a/source/wifi/wifi_hal_hapd.c
+++ b/source/wifi/wifi_hal_hapd.c
@@ -196,7 +196,7 @@ int hapd_read_cfg(hapd_cfg_t *cfg, const char *filename)
     size_t len = 0;
     ssize_t nread;
 
-    DBG("Hapd: Parse configuration '%s'\n", filename);
+    // DBG("Hapd: Parse configuration '%s'\n", filename);
     stream = fopen(filename, "r");
     if (stream == NULL)
     {


### PR DESCRIPTION
Configuration options from hostapd.conf file are shared between wifiagent and opensync, thus they can not be cached, and must be read from file each time the query is performed.

Signed-off-by: Tomasz Kilarski <tomasz.kilarski@consult.red>