### PR TITLE
REFPLTB-962 : Resolve wifi hal(hal-wifi-cfg80211) build time warnings

### DIFF
--- a/source/wifi/wifi_hal.c
+++ b/source/wifi/wifi_hal.c
@@ -7839,7 +7839,7 @@ static int ieee80211_channel_to_frequency(int channel, int *freqMHz)
     return 0;
 }
 
-static int get_survey_dump_buf(INT radioIndex, int channel, const char *buf, size_t bufsz)
+static int get_survey_dump_buf(INT radioIndex, int channel, char *buf, size_t bufsz)
 {
     int freqMHz = -1;
     char cmd[MAX_CMD_SIZE] = {'\0'};


### PR DESCRIPTION
Reason for change: To resolve Wdiscarded-qualifiers warnings in hal-wifi-cfg80211 Test Procedure: Build and checked for warnings
Risks: low

Signed-off-by: Ssandhyarani <sirasanagandla.sandhyarani@ltts.com>