### PR TITLE
REFPLTB-1927 : [TDK][AUTO][Turris]Invoking the HAL API wifi_delApAclDevices() with invalid apIndex returns success

### DIFF
--- a/source/wifi/wifi_hal.c
+++ b/source/wifi/wifi_hal.c
@@ -7405,6 +7405,8 @@ INT wifi_delApAclDevices(INT apIndex)
     FILE *fp;
     BOOL apEnabled = false;
 
+    if(apIndex < 0 || apIndex >= MAX_APS)
+        return RETURN_ERR;
 
     snprintf(fname, sizeof(fname), "%s%d", ACL_PREFIX, apIndex);
     fp = fopen(fname, "w");
@@ -9087,6 +9089,13 @@ int main(int argc,char **argv)
                 hapd_print_cfg(&cfg);
             }
         }
+    }
+
+    if (strstr(argv[1], "wifi_delApAclDevices") != NULL)
+    {
+         if(wifi_delApAclDevices(index) != RETURN_OK)
+             printf("Error returned\n");
+         return 0;
     }
 
     WIFI_ENTRY_EXIT_DEBUG("Exiting %s:%d\n",__func__, __LINE__);


### PR DESCRIPTION
Reason for change : Getting Success scenario even for an invalid apIndex 
Test Procedure: Included apIndex error condition & also testapp for wifi_delApAclDevices 
Risks: Low

Signed-off-by: kosika.saipriya <kosika.saipriya@ltts.com>