### PR TITLE
EXTLTSS-154:Fix get/set country code in wifihal 3.0 for TurrisOmnia

### DIFF
--- a/source/wifi/wifi_hal.c
+++ b/source/wifi/wifi_hal.c
@@ -167,7 +167,7 @@ typedef enum
 #endif /* ARRAY_AND_SIZE */
 
 #define WIFI_ITEM_STR(key, str)        {0, sizeof(str)-1, (int)key, (intptr_t)str}
-
+//ISO 3166 Country Codes - ISO allows free-of-charge use of its country codes.
 const char *country_codeMap[] = { "AC","AD","AE","AF","AG","AI","AL","AM","AN","AO","AQ","AR","AS","AT","AU","AW","AZ","BA","BB","BD","BE","BF","BG","BH","BI","BJ","BM","BN","BO","BR","BS","BT","BV","BW","BY","BZ","CA","CC","CD","CF","CG","CH","CI","CK","CL","CM","CN","CO","CP","CR","CU","CV","CY","CX","CZ","DE","DJ","DK","DM","DO","DZ","EC","EE","EG","EH","ER","ES","ET","FI","FJ","FK","FM","FO","FR","GA","GB","GD","GE","GF","GG","GH","GI","GL","GM","GN","GP","GQ","GR","GS","GT","GU","GW","GY","HR","HT","HM","HN","HK","HU","IS","IN","ID", "IR","IQ","IE","IL","IM","IT","IO","JM","JP","JE","JO","KE","KG","KH","KI","KM","KN","KP","KR","KW","KY","KZ","LA","LB","LC","LI","LK","LR","LS","LT","LU","LV","LY","MA","MC","MD","ME","MG","MH","MK","ML","MM","MN","MO","MQ","MR","MS","MT","MU","MV","MW","MX","MY","MZ","NA","NC","NE","NF","NG","NI","NL","NO","NP","NR","NU","NZ","MP","OM","PA","PE","PF","PG","PH","PK","PL","PM","PN","PR","PS","PT","PW","PY","QA","RE","RO","RS","RU","RW","SA","SB","SD","SE","SC","SG","SH","SI","SJ","SK","SL","SM","SN","SO","SR","ST","SV","SY","SZ","TA","TC","TD","TF","TG","TH","TJ","TK","TL","TM","TN","TO","TR","TT","TV","TW","TZ","UA","UG","UM","US","UY","UZ","VA","VC","VE","VG","VI","VN","VU","WF","WS","YE","YT","YU","ZA","ZM","ZW","MAX" };
 
 typedef struct {


### PR DESCRIPTION
Reason for change: Current implementation of countrycode is hardcoded in turris.Turris omnia uses different regulatory domain country code than hardcoded. To fix this issue this ticket implements countrycode using iw reg command. Test Procedure:Updated in the ticket.
Risks: low

Signed-off-by: Aravinth PV <aravinth.pv@ltts.com>